### PR TITLE
Fix the bug which will return fake server ip when there is more than …

### DIFF
--- a/l2tp-ipsec-install-script-for-centos7.sh
+++ b/l2tp-ipsec-install-script-for-centos7.sh
@@ -34,7 +34,7 @@ printf "
 "
 
 #获取服务器IP
-serverip=$(hostname -i)
+serverip=$(ifconfig -a |grep -w "inet"| grep -v "127.0.0.1" |awk '{print $2;}')
 printf "\e[33m$serverip\e[0m is the server IP?"
 printf "If \e[33m$serverip\e[0m is \e[33mcorrect\e[0m, press enter directly."
 printf "If \e[33m$serverip\e[0m is \e[33mincorrect\e[0m, please input your server IP."


### PR DESCRIPTION
I used your script and there are some problem with my environment at first. Since there is a ipv6 address in my server, we can't get the correct ipv4 address use "hostname -i". After that I searched for the internet and found a way to go over it. I‘ve saved a lot effort with your this script so I want give feedback.
